### PR TITLE
Adding examples for ESP32 and M5StickC

### DIFF
--- a/examples/Example_ESP32/Example_ESP32.ino
+++ b/examples/Example_ESP32/Example_ESP32.ino
@@ -1,0 +1,41 @@
+#include <WiFi.h>
+#include "mapper.h"
+
+const char* ssid     = "WIFI_SSID";
+const char* password = "WIFI_PASSWORD";
+
+mapper_device dev = 0;
+mapper_signal input_signal = 0;
+mapper_signal output_signal = 0;
+float seq_number = 0;
+float received_value = 0;
+
+void setup() {
+  WiFi.begin(ssid, password);
+
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
+
+  float min = 0.0f;
+  float max = 5.0f;
+
+  dev = mapper_device_new("ESP32", 0, 0);
+  output_signal = mapper_device_add_output_signal(dev, "value_to_send", 1, 'f', "V", &min, &max);
+  input_signal = mapper_device_add_input_signal(dev, "value_received", 1, 'f', 0, &min, &max, input_signal_handler, 0);
+}
+
+void loop() {
+  mapper_device_poll(dev, 120);
+  seq_number = seq_number + 0.01f;
+  mapper_signal_update_float(output_signal, seq_number);
+}
+
+void input_signal_handler(mapper_signal sig, mapper_id instance, const void *value, int count, mapper_timetag_t *timetag) {
+  if (value) {
+    float *v = (float*)value;
+    for (int i = 0; i < mapper_signal_length(sig); i++) {
+      received_value = v[i];
+    }
+  }
+}

--- a/examples/Example_M5StickC/Example_M5StickC.ino
+++ b/examples/Example_M5StickC/Example_M5StickC.ino
@@ -1,0 +1,61 @@
+#include <WiFi.h>
+#include <M5StickC.h>
+#include "mapper.h"
+
+const char* ssid     = "WIFI_SSID";
+const char* password = "WIFI_PASSWORD";
+
+mapper_device dev = 0;
+mapper_signal input_signal = 0;
+mapper_signal output_signal = 0;
+float seq_number = 0;
+float received_value = 0;
+
+void setup() {
+  // Initialize the M5StickC object
+  M5.begin();
+
+  WiFi.begin(ssid, password);
+
+  while (WiFi.status() != WL_CONNECTED) {
+    M5.Lcd.fillScreen(ORANGE);
+    delay(250);
+    M5.Lcd.fillScreen(RED);
+    delay(250);
+    M5.Lcd.println("Connecting");
+  }
+
+  M5.Lcd.fillScreen(GREEN);
+
+  float min = 0.0f;
+  float max = 5.0f;
+
+  dev = mapper_device_new("M5StickC", 0, 0);
+  output_signal = mapper_device_add_output_signal(dev, "value_to_send", 1, 'f', "V", &min, &max);
+  input_signal = mapper_device_add_input_signal(dev, "value_received", 1, 'f', 0, &min, &max, input_signal_handler, 0);
+
+  // LCD display
+  // M5.Lcd.print("Hello World");
+
+  pinMode(M5_LED, OUTPUT);
+  digitalWrite(M5_LED, HIGH);
+}
+
+void loop() {
+  mapper_device_poll(dev, 120);
+  M5.Lcd.fillScreen(BLUE);
+  seq_number = seq_number + 0.01f;
+  mapper_signal_update_float(output_signal, seq_number);
+  M5.Lcd.setCursor(0, 10);
+  M5.Lcd.print(received_value);
+  //delay(10);
+}
+
+void input_signal_handler(mapper_signal sig, mapper_id instance, const void *value, int count, mapper_timetag_t *timetag) {
+  if (value) {
+    float *v = (float*)value;
+    for (int i = 0; i < mapper_signal_length(sig); i++) {
+      received_value = v[i];
+    }
+  }
+}


### PR DESCRIPTION
Hello @mathiasbredholt,
I propose to present some examples to the users so they could experiment with the libmapper_arduino more quickly with ESP32 and M5StickC. This is just a folder containing the examples, the next step is to update the Makefile to copy the files to the resulting examples folder. Following the Arduino library structure, the examples folder is at the same level as src folder. I didn't update the Makefile yet, because I'm having an [issue](https://github.com/mathiasbredholt/libmapper_arduino/issues/3) to execute the make command.
Thank you a lot for this initiative!
Cheers! 