### PR TITLE
update-library: fix sed compatibility for Linux and macOS

### DIFF
--- a/update-library.sh
+++ b/update-library.sh
@@ -1,6 +1,11 @@
 #!/bin/zsh
 cd -- "$(dirname "$BASH_SOURCE")"
 
+SEDOPTION=
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  SEDOPTION="''"
+fi
+
 rm -rf src
 mkdir src
 
@@ -16,7 +21,7 @@ cd libmapper
 ./autogen.sh
 mkdir -p ../../src/mapper
 # Include compat.h at beginning of each source file
-for i in src/*.c; do sed -i '' '1i\
+for i in src/*.c; do sed -i $SEDOPTION '1i\
 #include <compat.h>
 ' $i ; done
 cp src/*.c ../../src/mapper
@@ -31,7 +36,7 @@ cd liblo
 ./autogen.sh
 mkdir -p ../../src/lo
 # # Include compat.h at beginning of each source file
-for i in src/*.c; do sed -i '' '1i\
+for i in src/*.c; do sed -i $SEDOPTION '1i\
 #include <compat.h>
 ' $i ; done
 cp src/address.c ../../src/lo


### PR DESCRIPTION
Hi @mathiasbredholt 

`./update-library.sh` will silently fail on Linux with traces of: `sed: can't read 1i\`.
While sed on macOS requires `-i ''` for inplace replacements, GNU sed on Linux needs `-i` without `''`.
See: https://stackoverflow.com/questions/43171648/sed-gives-sed-cant-read-no-such-file-or-directory

Does the test to define `SEDOPTION` added in this PR work on your zsh on macOS (works with bash on Linux)?